### PR TITLE
Add dotfiles management and migrate to go-task

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,12 +2,18 @@
 # Run: brew bundle --file Brewfile
 
 # =============================================================================
+# TAPS
+# =============================================================================
+tap "homebrew/cask-fonts"      # For Nerd Fonts
+
+# =============================================================================
 # CORE (install order matters for some dependencies)
 # =============================================================================
 brew "zsh"
 brew "git"
 brew "gh"                      # GitHub CLI - essential for Claude Code workflows
 brew "gnupg"
+brew "mas"                     # Mac App Store CLI
 
 # =============================================================================
 # NODE.JS (required for Claude Code: npm install -g @anthropic-ai/claude-code)
@@ -51,11 +57,13 @@ brew "wget"
 # APPLICATIONS - Security (install first on new machine)
 # =============================================================================
 cask "1password"
+cask "1password-cli"               # CLI for automation (op command)
 
 # =============================================================================
 # APPLICATIONS - AI & Development
 # =============================================================================
 cask "zed"                     # AI-native code editor
+cask "visual-studio-code"      # VS Code
 cask "warp"                    # AI-powered terminal
 cask "iterm2"
 cask "sublime-text"
@@ -65,6 +73,7 @@ cask "chatgpt"                 # OpenAI desktop app
 cask "postman"
 cask "ngrok"
 cask "postico"                 # PostgreSQL GUI
+cask "redis-insight"           # Redis GUI
 
 # =============================================================================
 # APPLICATIONS - Browsers
@@ -76,6 +85,7 @@ cask "firefox"
 # APPLICATIONS - Productivity
 # =============================================================================
 cask "raycast"                 # Launcher with AI features
+cask "cleanshot"               # Screenshot tool (better than built-in)
 cask "linear-linear"
 cask "zoom"
 cask "loom"
@@ -90,4 +100,25 @@ cask "whatsapp"
 cask "reader"
 cask "kindle"
 cask "perimeter81"
+
+# =============================================================================
+# FONTS (Nerd Fonts for terminal icons - required for powerlevel10k)
+# =============================================================================
+cask "font-meslo-lg-nerd-font"        # Recommended for p10k
+cask "font-fira-code-nerd-font"       # Popular coding font with ligatures
+cask "font-jetbrains-mono-nerd-font"  # JetBrains Mono with icons
+cask "font-hack-nerd-font"            # Clean monospace font
+
+# =============================================================================
+# MAC APP STORE APPS (requires: mas signin)
+# Use `mas search <app>` to find IDs, `mas list` to see installed
+# =============================================================================
+mas "Xcode", id: 497799835
+mas "1Password for Safari", id: 1569813296
+mas "Kindle", id: 302584613
+mas "Okta Extension App", id: 1439967473
+# mas "Slack", id: 803453959          # Using browser/desktop app instead?
+# mas "Things 3", id: 904280696       # Uncomment if you use Things
+# mas "Magnet", id: 441258766         # Window manager (Raycast has this built-in)
+# mas "Bear", id: 1091189122          # Note-taking app
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,15 +1,93 @@
-# Brewfile
+# Brewfile - AI Development Environment
+# Run: brew bundle --file Brewfile
 
+# =============================================================================
+# CORE (install order matters for some dependencies)
+# =============================================================================
 brew "zsh"
 brew "git"
+brew "gh"                      # GitHub CLI - essential for Claude Code workflows
+brew "gnupg"
+
+# =============================================================================
+# NODE.JS (required for Claude Code: npm install -g @anthropic-ai/claude-code)
+# =============================================================================
 brew "node"
-brew "python"
-cask "warp"
-cask "google-chrome"
+brew "nvm"                     # Node version manager
+
+# =============================================================================
+# PYTHON & AI/ML DEVELOPMENT
+# =============================================================================
+brew "python"                  # Latest Python
+brew "python@3.12"             # Stable for most ML libraries
+brew "uv"                      # Fast Python package manager (pip replacement)
+brew "poetry"                  # Dependency management for projects
+
+# =============================================================================
+# DATA & DATABASES
+# =============================================================================
+brew "duckdb"                  # Fast analytics database
+brew "postgresql@14"
+brew "jq"                      # JSON processor (useful for API responses)
+
+# =============================================================================
+# CLOUD & INFRASTRUCTURE
+# =============================================================================
+brew "awscli"
+brew "google-cloud-sdk"
+brew "terraform"
+brew "docker-compose"
+
+# =============================================================================
+# DEVELOPMENT TOOLS
+# =============================================================================
+brew "vercel-cli"
+brew "hugo"
+brew "go-task"                 # Task runner
+brew "cmake"                   # Build tool (needed for some ML packages)
+brew "wget"
+
+# =============================================================================
+# APPLICATIONS - Security (install first on new machine)
+# =============================================================================
+cask "1password"
+
+# =============================================================================
+# APPLICATIONS - AI & Development
+# =============================================================================
 cask "visual-studio-code"
-cask "spotify"
-cask "raycast"
-cask "linear-linear"
-cask "firefox"
-cask "zoom"
+cask "warp"                    # AI-powered terminal
+cask "iterm2"
 cask "sublime-text"
+cask "docker"
+cask "ollama"                  # Local LLM runner
+cask "chatgpt"                 # OpenAI desktop app
+cask "postman"
+cask "ngrok"
+cask "postico"                 # PostgreSQL GUI
+
+# =============================================================================
+# APPLICATIONS - Browsers
+# =============================================================================
+cask "google-chrome"
+cask "firefox"
+
+# =============================================================================
+# APPLICATIONS - Productivity
+# =============================================================================
+cask "raycast"                 # Launcher with AI features
+cask "linear-linear"
+cask "zoom"
+cask "loom"
+cask "figma"
+cask "logitech-options"
+
+# =============================================================================
+# APPLICATIONS - Other
+# =============================================================================
+cask "spotify"
+cask "whatsapp"
+cask "reader"
+cask "kindle"
+cask "perimeter81"
+

--- a/Brewfile
+++ b/Brewfile
@@ -55,7 +55,7 @@ cask "1password"
 # =============================================================================
 # APPLICATIONS - AI & Development
 # =============================================================================
-cask "visual-studio-code"
+cask "zed"                     # AI-native code editor
 cask "warp"                    # AI-powered terminal
 cask "iterm2"
 cask "sublime-text"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,175 @@
+# init
+
+Declarative, idempotent Mac setup for AI development workflows.
+
+## Quick Start
+
+```bash
+# Fresh Mac - run everything
+./init.sh
+
+# Or use individual tasks
+task brew        # Install Homebrew packages
+task dotfiles    # Symlink configuration files
+task git         # Configure git
+task claude      # Install Claude Code
+```
+
+## Requirements
+
+- macOS (Apple Silicon or Intel)
+- Internet connection
+
+The script will install Homebrew and go-task automatically if needed.
+
+## What's Included
+
+### CLI Tools
+
+| Tool | Purpose |
+|------|---------|
+| `uv` | Fast Python package manager |
+| `node` / `nvm` | JavaScript runtime (required for Claude Code) |
+| `gh` | GitHub CLI |
+| `claude` | Claude Code AI assistant |
+| `duckdb` | Analytics database |
+| `awscli` / `gcloud` | Cloud CLIs |
+| `terraform` | Infrastructure as code |
+
+### Applications
+
+| App | Purpose |
+|-----|---------|
+| 1Password | Password manager (install first) |
+| Zed | AI-native code editor |
+| Warp | AI-powered terminal |
+| Ollama | Local LLM runner |
+| ChatGPT | OpenAI desktop app |
+| Raycast | Launcher with AI features |
+
+### Dotfiles
+
+Managed configuration files (symlinked from `dotfiles/`):
+
+- `~/.zshrc` - Zsh configuration with oh-my-zsh
+- `~/.p10k.zsh` - Powerlevel10k theme
+- `~/.config/zed/settings.json` - Zed editor settings
+
+## Tasks
+
+```bash
+task --list              # Show all available tasks
+
+# Main tasks
+task all                 # Full setup
+task brew                # Homebrew packages only
+task dotfiles            # Symlink dotfiles only
+task git                 # Git config only
+task claude              # Claude Code only
+
+# Homebrew
+task brew:bundle         # Install from Brewfile
+task brew:cleanup        # Remove unlisted packages
+task brew:dump           # Export current packages (caution)
+task brew:lock           # Update lock file
+
+# Dotfiles
+task dotfiles:zsh        # Symlink zsh config
+task dotfiles:zed        # Symlink Zed config
+task dotfiles:backup     # Copy system dotfiles to repo
+
+# Zsh plugins
+task zsh-plugins         # Install all zsh plugins
+task zsh-plugins:omz     # Install oh-my-zsh
+task zsh-plugins:p10k    # Install powerlevel10k
+
+# Utilities
+task status              # Show current setup status
+```
+
+## Structure
+
+```
+init/
+├── Brewfile              # Homebrew packages (formulae + casks)
+├── Brewfile.lock.json    # Locked versions for reproducibility
+├── Taskfile.yml          # Task definitions
+├── init.sh               # Bootstrap script (installs task, runs all)
+├── dotfiles/
+│   ├── zsh/
+│   │   ├── zshrc         # Main zsh config
+│   │   └── p10k.zsh      # Powerlevel10k theme config
+│   └── zed/
+│       └── settings.json # Zed editor settings
+└── .trunk/               # Code quality (shellcheck, shfmt)
+```
+
+## Customization
+
+### Adding packages
+
+Edit `Brewfile`:
+
+```ruby
+brew "your-formula"
+cask "your-app"
+```
+
+Then run `task brew:bundle`.
+
+### Modifying dotfiles
+
+1. Edit files in `dotfiles/` directory
+2. Run `task dotfiles` to re-symlink (or changes apply immediately since they're symlinked)
+
+### Backing up current config
+
+```bash
+task dotfiles:backup    # Copies current system dotfiles to repo
+```
+
+## Notes
+
+### Raycast
+
+Raycast syncs settings via iCloud. Export/import manually via Raycast > Settings > Advanced > Export.
+
+### GPG Keys
+
+Import your GPG keys manually for commit signing:
+
+```bash
+gpg --import private-key.asc
+```
+
+### First Run on New Mac
+
+1. Run `./init.sh`
+2. Open 1Password, sign in
+3. Run `claude` to authenticate with Anthropic API key
+4. Import GPG keys
+5. Configure Raycast (import from iCloud or previous export)
+
+## Troubleshooting
+
+### Dotfiles not updating
+
+Check symlinks are correct:
+```bash
+task status
+```
+
+### Brew packages out of sync
+
+```bash
+task brew:cleanup
+task brew:bundle
+```
+
+### Reset dotfiles to repo version
+
+```bash
+rm ~/.zshrc ~/.p10k.zsh
+task dotfiles
+source ~/.zshrc
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,13 +15,25 @@ tasks:
   # ===========================================================================
 
   all:
-    desc: Run full setup (brew, dotfiles, git, claude)
+    desc: Run full setup (brew, dotfiles, macos, git, ssh, tmux, claude)
     cmds:
       - task: brew
       - task: dotfiles
       - task: zsh-plugins
+      - task: tmux-plugins
       - task: git
+      - task: ssh
+      - task: macos
       - task: claude
+
+  backup-1password:
+    desc: Back up all secrets to 1Password (SSH, GPG, dbt)
+    cmds:
+      - task: ssh:backup-1password
+      - task: gpg:backup-1password
+      - task: dbt:backup-1password
+      - echo ""
+      - echo "=== All secrets backed up to 1Password ==="
 
   # ===========================================================================
   # HOMEBREW
@@ -80,6 +92,9 @@ tasks:
     cmds:
       - task: dotfiles:zsh
       - task: dotfiles:zed
+      - task: dotfiles:git
+      - task: dotfiles:ssh
+      - task: dotfiles:tmux
 
   dotfiles:zsh:
     desc: Symlink zsh configuration
@@ -105,12 +120,53 @@ tasks:
       - ln -sf {{.DOTFILES_DIR}}/zed/settings.json ~/.config/zed/settings.json
       - echo "Symlinked Zed config"
 
+  dotfiles:git:
+    desc: Symlink git configuration
+    cmds:
+      - |
+        if [ -f ~/.gitconfig ] && [ ! -L ~/.gitconfig ]; then
+          echo "Backing up existing .gitconfig to .gitconfig.backup"
+          mv ~/.gitconfig ~/.gitconfig.backup
+        fi
+      - ln -sf {{.DOTFILES_DIR}}/git/gitconfig ~/.gitconfig
+      - ln -sf {{.DOTFILES_DIR}}/git/gitignore_global ~/.gitignore_global
+      - echo "Symlinked git config"
+
+  dotfiles:ssh:
+    desc: Symlink SSH configuration
+    cmds:
+      - mkdir -p ~/.ssh/sockets
+      - chmod 700 ~/.ssh
+      - |
+        if [ -f ~/.ssh/config ] && [ ! -L ~/.ssh/config ]; then
+          echo "Backing up existing SSH config"
+          mv ~/.ssh/config ~/.ssh/config.backup
+        fi
+      - ln -sf {{.DOTFILES_DIR}}/ssh/config ~/.ssh/config
+      - chmod 600 ~/.ssh/config
+      - echo "Symlinked SSH config"
+
+  dotfiles:tmux:
+    desc: Symlink tmux configuration
+    cmds:
+      - |
+        if [ -f ~/.tmux.conf ] && [ ! -L ~/.tmux.conf ]; then
+          echo "Backing up existing .tmux.conf to .tmux.conf.backup"
+          mv ~/.tmux.conf ~/.tmux.conf.backup
+        fi
+      - ln -sf {{.DOTFILES_DIR}}/tmux/tmux.conf ~/.tmux.conf
+      - echo "Symlinked tmux config"
+
   dotfiles:backup:
     desc: Copy current dotfiles from system to this repo
     cmds:
       - cp ~/.zshrc {{.DOTFILES_DIR}}/zsh/zshrc
       - cp ~/.p10k.zsh {{.DOTFILES_DIR}}/zsh/p10k.zsh
       - cp ~/.config/zed/settings.json {{.DOTFILES_DIR}}/zed/settings.json
+      - cp ~/.gitconfig {{.DOTFILES_DIR}}/git/gitconfig 2>/dev/null || true
+      - cp ~/.gitignore_global {{.DOTFILES_DIR}}/git/gitignore_global 2>/dev/null || true
+      - cp ~/.ssh/config {{.DOTFILES_DIR}}/ssh/config 2>/dev/null || true
+      - cp ~/.tmux.conf {{.DOTFILES_DIR}}/tmux/tmux.conf 2>/dev/null || true
       - echo "Dotfiles backed up to repo"
 
   # ===========================================================================
@@ -158,20 +214,374 @@ tasks:
       - git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
   # ===========================================================================
+  # TMUX PLUGINS
+  # ===========================================================================
+
+  tmux-plugins:
+    desc: Install tmux plugin manager and plugins
+    cmds:
+      - task: tmux-plugins:tpm
+
+  tmux-plugins:tpm:
+    desc: Install TPM (Tmux Plugin Manager)
+    status:
+      - test -d ~/.tmux/plugins/tpm
+    cmds:
+      - echo "Installing TPM..."
+      - git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+      - echo "TPM installed. Run 'prefix + I' in tmux to install plugins."
+
+  # ===========================================================================
   # GIT
   # ===========================================================================
 
   git:
-    desc: Configure git globally
+    desc: Symlink git configuration (replaces git config commands)
     cmds:
-      - git config --global user.name "Saadat Qadri"
-      - git config --global user.email "saadat.qadri@gmail.com"
-      - git config --global init.defaultBranch main
-      - git config --global core.editor "zed --wait"
-      - git config --global credential.helper cache
-      - git config --global user.signingkey 3CD5D6A0B9B8F207
-      - git config --global commit.gpgsign true
-      - echo "Git configured"
+      - task: dotfiles:git
+      - echo "Git configured via dotfile symlink"
+
+  # ===========================================================================
+  # SSH
+  # ===========================================================================
+
+  ssh:
+    desc: Setup SSH configuration and generate keys if needed
+    cmds:
+      - task: dotfiles:ssh
+      - task: ssh:keygen
+      - echo "SSH configured. See scripts/ssh-backup-1password.md for key backup guide."
+
+  ssh:keygen:
+    desc: Generate SSH keys for GitHub accounts if not present
+    cmds:
+      - task: ssh:keygen:saadatqadri
+      - task: ssh:keygen:heyarchie
+
+  ssh:keygen:saadatqadri:
+    desc: Generate SSH key for saadatqadri GitHub
+    status:
+      - test -f ~/.ssh/id_ed25519_saadatqadri
+    cmds:
+      - echo "Generating SSH key for saadatqadri..."
+      - ssh-keygen -t ed25519 -C "saadatqadri@github" -f ~/.ssh/id_ed25519_saadatqadri -N ""
+      - chmod 600 ~/.ssh/id_ed25519_saadatqadri
+      - chmod 644 ~/.ssh/id_ed25519_saadatqadri.pub
+      - echo ""
+      - echo "Add this key to GitHub (saadatqadri account):"
+      - echo "  gh ssh-key add ~/.ssh/id_ed25519_saadatqadri.pub --title \"$(hostname)-saadatqadri\""
+      - cat ~/.ssh/id_ed25519_saadatqadri.pub
+
+  ssh:keygen:heyarchie:
+    desc: Generate SSH key for HeyArchie GitHub
+    status:
+      - test -f ~/.ssh/id_ed25519_heyarchie
+    cmds:
+      - echo "Generating SSH key for HeyArchie..."
+      - ssh-keygen -t ed25519 -C "saadat-heyarchie@github" -f ~/.ssh/id_ed25519_heyarchie -N ""
+      - chmod 600 ~/.ssh/id_ed25519_heyarchie
+      - chmod 644 ~/.ssh/id_ed25519_heyarchie.pub
+      - echo ""
+      - echo "Add this key to GitHub (saadat-heyarchie account):"
+      - cat ~/.ssh/id_ed25519_heyarchie.pub
+
+  ssh:show:
+    desc: Display public SSH keys
+    cmds:
+      - echo "=== SSH Public Keys ==="
+      - |
+        for key in ~/.ssh/*.pub; do
+          if [ -f "$key" ]; then
+            echo ""
+            echo "--- $key ---"
+            cat "$key"
+          fi
+        done
+
+  ssh:add-github:
+    desc: Add SSH key to GitHub using gh CLI
+    cmds:
+      - gh ssh-key add ~/.ssh/id_ed25519.pub --title "$(hostname) $(date +%Y)"
+      - echo "SSH key added to GitHub"
+
+  ssh:backup-1password:
+    desc: Back up all SSH keys to 1Password
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "Error: 1Password CLI not installed. Run: brew install 1password-cli"
+          exit 1
+        fi
+      - |
+        # Check if signed in
+        if ! op account list &> /dev/null; then
+          echo "Please sign in to 1Password CLI first:"
+          echo "  eval \$(op signin)"
+          exit 1
+        fi
+      - |
+        echo "Backing up SSH keys to 1Password..."
+
+        # Define keys to back up (name:path pairs)
+        declare -A keys=(
+          ["SSH Key - saadatqadri GitHub"]="$HOME/.ssh/id_ed25519_saadatqadri"
+          ["SSH Key - HeyArchie GitHub"]="$HOME/.ssh/id_ed25519_heyarchie"
+          ["SSH Key - Archie (legacy)"]="$HOME/.ssh/archie_id_ed25519"
+          ["SSH Key - Personal (legacy)"]="$HOME/.ssh/id_ed25519"
+        )
+
+        for title in "${!keys[@]}"; do
+          key_path="${keys[$title]}"
+
+          if [ -f "$key_path" ]; then
+            echo "Backing up: $title"
+
+            # Check if item already exists
+            if op item get "$title" &> /dev/null; then
+              echo "  Item exists, updating..."
+              op item edit "$title" \
+                "private_key[password]=$(cat "$key_path")" \
+                "public_key[text]=$(cat "${key_path}.pub")" \
+                "notes[text]=Updated from $(hostname) on $(date)"
+            else
+              echo "  Creating new item..."
+              op item create \
+                --category="Secure Note" \
+                --title="$title" \
+                "private_key[password]=$(cat "$key_path")" \
+                "public_key[text]=$(cat "${key_path}.pub")" \
+                "notes[text]=Backed up from $(hostname) on $(date)"
+            fi
+          else
+            echo "Skipping $title (not found at $key_path)"
+          fi
+        done
+
+        echo ""
+        echo "Backup complete! Keys stored in 1Password."
+
+  ssh:restore-1password:
+    desc: Restore SSH keys from 1Password
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "Error: 1Password CLI not installed. Run: brew install 1password-cli"
+          exit 1
+        fi
+      - |
+        if ! op account list &> /dev/null; then
+          echo "Please sign in to 1Password CLI first:"
+          echo "  eval \$(op signin)"
+          exit 1
+        fi
+      - |
+        echo "Available SSH keys in 1Password:"
+        op item list --categories "Secure Note" | grep -i "SSH Key" || echo "  No SSH keys found"
+        echo ""
+        echo "To restore a specific key, run:"
+        echo "  op item get 'SSH Key - Personal GitHub' --fields private_key > ~/.ssh/id_ed25519"
+        echo "  op item get 'SSH Key - Personal GitHub' --fields public_key > ~/.ssh/id_ed25519.pub"
+        echo "  chmod 600 ~/.ssh/id_ed25519 && chmod 644 ~/.ssh/id_ed25519.pub"
+
+  # ===========================================================================
+  # GPG
+  # ===========================================================================
+
+  gpg:backup-1password:
+    desc: Back up GPG keys to 1Password
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "Error: 1Password CLI not installed. Run: brew install 1password-cli"
+          exit 1
+        fi
+      - |
+        if ! op account list &> /dev/null; then
+          echo "Please sign in to 1Password CLI first:"
+          echo "  eval \$(op signin)"
+          exit 1
+        fi
+      - |
+        if ! command -v gpg &> /dev/null; then
+          echo "Error: GPG not installed. Run: brew install gnupg"
+          exit 1
+        fi
+      - |
+        echo "Available GPG secret keys:"
+        gpg --list-secret-keys --keyid-format LONG
+        echo ""
+
+        # Get key IDs
+        key_ids=$(gpg --list-secret-keys --keyid-format LONG | grep "sec" | awk '{print $2}' | cut -d'/' -f2)
+
+        if [ -z "$key_ids" ]; then
+          echo "No GPG secret keys found."
+          exit 0
+        fi
+
+        for key_id in $key_ids; do
+          # Get user ID (email) for this key
+          user_id=$(gpg --list-secret-keys --keyid-format LONG "$key_id" | grep "uid" | head -1 | sed 's/.*] //')
+          title="GPG Key - $key_id"
+
+          echo "Backing up: $title ($user_id)"
+
+          # Export keys to temp files
+          private_key=$(gpg --armor --export-secret-keys "$key_id")
+          public_key=$(gpg --armor --export "$key_id")
+
+          # Check if item already exists
+          if op item get "$title" &> /dev/null; then
+            echo "  Item exists, updating..."
+            op item edit "$title" \
+              "private_key[password]=$private_key" \
+              "public_key[text]=$public_key" \
+              "key_id[text]=$key_id" \
+              "user_id[text]=$user_id" \
+              "notes[text]=Updated from $(hostname) on $(date)"
+          else
+            echo "  Creating new item..."
+            op item create \
+              --category="Secure Note" \
+              --title="$title" \
+              "private_key[password]=$private_key" \
+              "public_key[text]=$public_key" \
+              "key_id[text]=$key_id" \
+              "user_id[text]=$user_id" \
+              "notes[text]=Backed up from $(hostname) on $(date)"
+          fi
+        done
+
+        echo ""
+        echo "GPG backup complete!"
+
+  gpg:restore-1password:
+    desc: Restore GPG keys from 1Password
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "Error: 1Password CLI not installed. Run: brew install 1password-cli"
+          exit 1
+        fi
+      - |
+        if ! op account list &> /dev/null; then
+          echo "Please sign in to 1Password CLI first:"
+          echo "  eval \$(op signin)"
+          exit 1
+        fi
+      - |
+        echo "Available GPG keys in 1Password:"
+        op item list --categories "Secure Note" | grep -i "GPG Key" || echo "  No GPG keys found"
+        echo ""
+        echo "To restore a specific key, run:"
+        echo "  op item get 'GPG Key - KEYID' --fields private_key | gpg --import"
+        echo ""
+        echo "After importing, trust the key:"
+        echo "  gpg --edit-key KEYID"
+        echo "  > trust"
+        echo "  > 5 (ultimate trust)"
+        echo "  > quit"
+
+  # ===========================================================================
+  # DBT
+  # ===========================================================================
+
+  dbt:backup-1password:
+    desc: Back up ~/.dbt folder to 1Password
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "Error: 1Password CLI not installed. Run: brew install 1password-cli"
+          exit 1
+        fi
+      - |
+        if ! op account list &> /dev/null; then
+          echo "Please sign in to 1Password CLI first:"
+          echo "  eval \$(op signin)"
+          exit 1
+        fi
+      - |
+        if [ ! -d ~/.dbt ]; then
+          echo "No ~/.dbt folder found."
+          exit 0
+        fi
+
+        echo "Backing up ~/.dbt to 1Password..."
+
+        title="dbt Config - $(hostname)"
+
+        # Read file contents
+        profiles_yml=""
+        dbt_cloud_yml=""
+        user_yml=""
+
+        [ -f ~/.dbt/profiles.yml ] && profiles_yml=$(cat ~/.dbt/profiles.yml)
+        [ -f ~/.dbt/dbt_cloud.yml ] && dbt_cloud_yml=$(cat ~/.dbt/dbt_cloud.yml)
+        [ -f ~/.dbt/.user.yml ] && user_yml=$(cat ~/.dbt/.user.yml)
+
+        # Check if item already exists
+        if op item get "$title" &> /dev/null; then
+          echo "Item exists, updating..."
+          op item edit "$title" \
+            "profiles_yml[password]=$profiles_yml" \
+            "dbt_cloud_yml[text]=$dbt_cloud_yml" \
+            "user_yml[text]=$user_yml" \
+            "notes[text]=Updated from $(hostname) on $(date)"
+        else
+          echo "Creating new item..."
+          op item create \
+            --category="Secure Note" \
+            --title="$title" \
+            "profiles_yml[password]=$profiles_yml" \
+            "dbt_cloud_yml[text]=$dbt_cloud_yml" \
+            "user_yml[text]=$user_yml" \
+            "notes[text]=Backed up from $(hostname) on $(date)"
+        fi
+
+        echo ""
+        echo "dbt config backup complete!"
+
+  dbt:restore-1password:
+    desc: Restore ~/.dbt folder from 1Password
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "Error: 1Password CLI not installed. Run: brew install 1password-cli"
+          exit 1
+        fi
+      - |
+        if ! op account list &> /dev/null; then
+          echo "Please sign in to 1Password CLI first:"
+          echo "  eval \$(op signin)"
+          exit 1
+        fi
+      - |
+        echo "Available dbt configs in 1Password:"
+        op item list --categories "Secure Note" | grep -i "dbt Config" || echo "  No dbt configs found"
+        echo ""
+        echo "To restore, run:"
+        echo "  mkdir -p ~/.dbt"
+        echo "  op item get 'dbt Config - HOSTNAME' --fields 'profiles_yml' > ~/.dbt/profiles.yml"
+        echo "  op item get 'dbt Config - HOSTNAME' --fields 'dbt_cloud_yml' > ~/.dbt/dbt_cloud.yml"
+        echo "  op item get 'dbt Config - HOSTNAME' --fields 'user_yml' > ~/.dbt/.user.yml"
+        echo "  chmod 600 ~/.dbt/profiles.yml"
+
+  # ===========================================================================
+  # MACOS DEFAULTS
+  # ===========================================================================
+
+  macos:
+    desc: Apply macOS system preferences
+    cmds:
+      - chmod +x {{.ROOT_DIR}}/scripts/macos-defaults.sh
+      - "{{.ROOT_DIR}}/scripts/macos-defaults.sh"
+
+  macos:reset-dock:
+    desc: Reset dock to default state
+    cmds:
+      - defaults delete com.apple.dock
+      - killall Dock
+      - echo "Dock reset to defaults"
 
   # ===========================================================================
   # CLAUDE CODE
@@ -207,9 +617,24 @@ tasks:
         [ -L ~/.zshrc ] && echo "  ~/.zshrc -> $(readlink ~/.zshrc)" || echo "  ~/.zshrc: not symlinked"
         [ -L ~/.p10k.zsh ] && echo "  ~/.p10k.zsh -> $(readlink ~/.p10k.zsh)" || echo "  ~/.p10k.zsh: not symlinked"
         [ -L ~/.config/zed/settings.json ] && echo "  ~/.config/zed/settings.json -> $(readlink ~/.config/zed/settings.json)" || echo "  ~/.config/zed/settings.json: not symlinked"
+        [ -L ~/.gitconfig ] && echo "  ~/.gitconfig -> $(readlink ~/.gitconfig)" || echo "  ~/.gitconfig: not symlinked"
+        [ -L ~/.gitignore_global ] && echo "  ~/.gitignore_global -> $(readlink ~/.gitignore_global)" || echo "  ~/.gitignore_global: not symlinked"
+        [ -L ~/.ssh/config ] && echo "  ~/.ssh/config -> $(readlink ~/.ssh/config)" || echo "  ~/.ssh/config: not symlinked"
+        [ -L ~/.tmux.conf ] && echo "  ~/.tmux.conf -> $(readlink ~/.tmux.conf)" || echo "  ~/.tmux.conf: not symlinked"
+      - echo ""
+      - echo "SSH Keys:"
+      - |
+        [ -f ~/.ssh/id_ed25519_saadatqadri ] && echo "  id_ed25519_saadatqadri: present" || echo "  id_ed25519_saadatqadri: not found"
+        [ -f ~/.ssh/id_ed25519_heyarchie ] && echo "  id_ed25519_heyarchie: present" || echo "  id_ed25519_heyarchie: not found"
+      - echo ""
+      - echo "Plugins:"
+      - |
+        [ -d ~/.oh-my-zsh ] && echo "  oh-my-zsh: installed" || echo "  oh-my-zsh: not installed"
+        [ -d ~/.tmux/plugins/tpm ] && echo "  TPM: installed" || echo "  TPM: not installed"
       - echo ""
       - echo "Tools:"
       - |
         command -v claude &> /dev/null && echo "  Claude Code: $(claude --version 2>/dev/null || echo 'installed')" || echo "  Claude Code: not installed"
         command -v node &> /dev/null && echo "  Node: $(node --version)" || echo "  Node: not installed"
         command -v uv &> /dev/null && echo "  uv: $(uv --version)" || echo "  uv: not installed"
+        command -v mas &> /dev/null && echo "  mas: installed" || echo "  mas: not installed"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,215 @@
+# https://taskfile.dev
+version: '3'
+
+vars:
+  DOTFILES_DIR: '{{.ROOT_DIR}}/dotfiles'
+
+tasks:
+  default:
+    desc: Show available tasks
+    cmds:
+      - task --list
+
+  # ===========================================================================
+  # MAIN TASKS
+  # ===========================================================================
+
+  all:
+    desc: Run full setup (brew, dotfiles, git, claude)
+    cmds:
+      - task: brew
+      - task: dotfiles
+      - task: zsh-plugins
+      - task: git
+      - task: claude
+
+  # ===========================================================================
+  # HOMEBREW
+  # ===========================================================================
+
+  brew:
+    desc: Install Homebrew and all packages from Brewfile
+    cmds:
+      - task: brew:install
+      - task: brew:bundle
+      - task: brew:cleanup
+
+  brew:install:
+    desc: Install Homebrew if not present
+    status:
+      - command -v brew
+    cmds:
+      - echo "Installing Homebrew..."
+      - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - |
+        if [[ $(uname -m) == "arm64" ]]; then
+          echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+          eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
+
+  brew:bundle:
+    desc: Install packages from Brewfile
+    cmds:
+      - brew update
+      - brew upgrade
+      - brew bundle --file {{.ROOT_DIR}}/Brewfile
+
+  brew:cleanup:
+    desc: Remove packages not in Brewfile
+    cmds:
+      - brew bundle cleanup --force --file {{.ROOT_DIR}}/Brewfile
+      - brew bundle check --file {{.ROOT_DIR}}/Brewfile
+
+  brew:dump:
+    desc: Export current brew packages to Brewfile (use with caution)
+    cmds:
+      - brew bundle dump --force --file {{.ROOT_DIR}}/Brewfile
+      - "echo 'Warning: Review Brewfile - may contain transitive dependencies'"
+
+  brew:lock:
+    desc: Update Brewfile.lock.json
+    cmds:
+      - brew bundle lock --file {{.ROOT_DIR}}/Brewfile
+
+  # ===========================================================================
+  # DOTFILES
+  # ===========================================================================
+
+  dotfiles:
+    desc: Symlink all dotfiles to home directory
+    cmds:
+      - task: dotfiles:zsh
+      - task: dotfiles:zed
+
+  dotfiles:zsh:
+    desc: Symlink zsh configuration
+    cmds:
+      - |
+        if [ -f ~/.zshrc ] && [ ! -L ~/.zshrc ]; then
+          echo "Backing up existing .zshrc to .zshrc.backup"
+          mv ~/.zshrc ~/.zshrc.backup
+        fi
+      - ln -sf {{.DOTFILES_DIR}}/zsh/zshrc ~/.zshrc
+      - ln -sf {{.DOTFILES_DIR}}/zsh/p10k.zsh ~/.p10k.zsh
+      - echo "Symlinked zsh config"
+
+  dotfiles:zed:
+    desc: Symlink Zed configuration
+    cmds:
+      - mkdir -p ~/.config/zed
+      - |
+        if [ -f ~/.config/zed/settings.json ] && [ ! -L ~/.config/zed/settings.json ]; then
+          echo "Backing up existing Zed settings"
+          mv ~/.config/zed/settings.json ~/.config/zed/settings.json.backup
+        fi
+      - ln -sf {{.DOTFILES_DIR}}/zed/settings.json ~/.config/zed/settings.json
+      - echo "Symlinked Zed config"
+
+  dotfiles:backup:
+    desc: Copy current dotfiles from system to this repo
+    cmds:
+      - cp ~/.zshrc {{.DOTFILES_DIR}}/zsh/zshrc
+      - cp ~/.p10k.zsh {{.DOTFILES_DIR}}/zsh/p10k.zsh
+      - cp ~/.config/zed/settings.json {{.DOTFILES_DIR}}/zed/settings.json
+      - echo "Dotfiles backed up to repo"
+
+  # ===========================================================================
+  # ZSH PLUGINS (not managed by Homebrew)
+  # ===========================================================================
+
+  zsh-plugins:
+    desc: Install oh-my-zsh and plugins
+    cmds:
+      - task: zsh-plugins:omz
+      - task: zsh-plugins:p10k
+      - task: zsh-plugins:autosuggestions
+      - task: zsh-plugins:syntax-highlighting
+
+  zsh-plugins:omz:
+    desc: Install oh-my-zsh
+    status:
+      - test -d ~/.oh-my-zsh
+    cmds:
+      - echo "Installing oh-my-zsh..."
+      - sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+  zsh-plugins:p10k:
+    desc: Install powerlevel10k theme
+    status:
+      - test -d ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+    cmds:
+      - echo "Installing powerlevel10k..."
+      - git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+
+  zsh-plugins:autosuggestions:
+    desc: Install zsh-autosuggestions
+    status:
+      - test -d ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+    cmds:
+      - echo "Installing zsh-autosuggestions..."
+      - git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+  zsh-plugins:syntax-highlighting:
+    desc: Install zsh-syntax-highlighting
+    status:
+      - test -d ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+    cmds:
+      - echo "Installing zsh-syntax-highlighting..."
+      - git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+
+  # ===========================================================================
+  # GIT
+  # ===========================================================================
+
+  git:
+    desc: Configure git globally
+    cmds:
+      - git config --global user.name "Saadat Qadri"
+      - git config --global user.email "saadat.qadri@gmail.com"
+      - git config --global init.defaultBranch main
+      - git config --global core.editor "zed --wait"
+      - git config --global credential.helper cache
+      - git config --global user.signingkey 3CD5D6A0B9B8F207
+      - git config --global commit.gpgsign true
+      - echo "Git configured"
+
+  # ===========================================================================
+  # CLAUDE CODE
+  # ===========================================================================
+
+  claude:
+    desc: Install or update Claude Code
+    cmds:
+      - |
+        if ! command -v claude &> /dev/null; then
+          echo "Installing Claude Code..."
+          npm install -g @anthropic-ai/claude-code
+        else
+          echo "Updating Claude Code..."
+          npm update -g @anthropic-ai/claude-code
+        fi
+      - echo "Claude Code ready. Run 'claude' to authenticate."
+
+  # ===========================================================================
+  # UTILITIES
+  # ===========================================================================
+
+  status:
+    desc: Show current setup status
+    cmds:
+      - echo "=== Setup Status ==="
+      - echo ""
+      - echo "Homebrew:"
+      - brew bundle check --file {{.ROOT_DIR}}/Brewfile || true
+      - echo ""
+      - echo "Dotfiles:"
+      - |
+        [ -L ~/.zshrc ] && echo "  ~/.zshrc -> $(readlink ~/.zshrc)" || echo "  ~/.zshrc: not symlinked"
+        [ -L ~/.p10k.zsh ] && echo "  ~/.p10k.zsh -> $(readlink ~/.p10k.zsh)" || echo "  ~/.p10k.zsh: not symlinked"
+        [ -L ~/.config/zed/settings.json ] && echo "  ~/.config/zed/settings.json -> $(readlink ~/.config/zed/settings.json)" || echo "  ~/.config/zed/settings.json: not symlinked"
+      - echo ""
+      - echo "Tools:"
+      - |
+        command -v claude &> /dev/null && echo "  Claude Code: $(claude --version 2>/dev/null || echo 'installed')" || echo "  Claude Code: not installed"
+        command -v node &> /dev/null && echo "  Node: $(node --version)" || echo "  Node: not installed"
+        command -v uv &> /dev/null && echo "  uv: $(uv --version)" || echo "  uv: not installed"

--- a/dotfiles/git/gitconfig
+++ b/dotfiles/git/gitconfig
@@ -1,0 +1,96 @@
+# Git configuration
+# Symlinked to ~/.gitconfig
+
+[user]
+    name = Saadat Qadri
+    email = saadat.qadri@gmail.com
+    signingkey = 3CD5D6A0B9B8F207
+
+[init]
+    defaultBranch = main
+
+[core]
+    editor = zed --wait
+    excludesfile = ~/.gitignore_global
+    autocrlf = input
+    pager = less -FRX
+
+[commit]
+    gpgsign = true
+
+[gpg]
+    program = /opt/homebrew/bin/gpg
+
+[credential]
+    helper = cache
+
+[credential "https://github.com"]
+    helper =
+    helper = !/opt/homebrew/bin/gh auth git-credential
+
+[credential "https://gist.github.com"]
+    helper =
+    helper = !/opt/homebrew/bin/gh auth git-credential
+
+[url "git@github.com:"]
+    insteadOf = https://github.com/
+
+[pull]
+    rebase = true
+
+[push]
+    default = current
+    autoSetupRemote = true
+
+[fetch]
+    prune = true
+
+[merge]
+    conflictstyle = diff3
+
+[diff]
+    colorMoved = default
+
+[rebase]
+    autoStash = true
+
+[alias]
+    # Status and info
+    s = status -sb
+    l = log --oneline -20
+    lg = log --oneline --graph --decorate -20
+    last = log -1 HEAD --stat
+
+    # Branching
+    co = checkout
+    cob = checkout -b
+    br = branch
+    brd = branch -d
+    brD = branch -D
+
+    # Staging and committing
+    a = add
+    aa = add --all
+    cm = commit -m
+    amend = commit --amend --no-edit
+
+    # Pushing and pulling
+    p = push
+    pf = push --force-with-lease
+    pl = pull
+
+    # Stashing
+    st = stash
+    stp = stash pop
+    stl = stash list
+
+    # Diff
+    d = diff
+    ds = diff --staged
+
+    # Undo
+    undo = reset HEAD~1 --mixed
+    unstage = reset HEAD --
+
+    # Clean
+    gone = "!git fetch -p && git branch -vv | grep ': gone]' | awk '{print $1}' | xargs -r git branch -D"

--- a/dotfiles/git/gitignore_global
+++ b/dotfiles/git/gitignore_global
@@ -1,0 +1,80 @@
+# Global gitignore
+# Symlinked to ~/.gitignore_global
+
+# ==============================================================================
+# macOS
+# ==============================================================================
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# ==============================================================================
+# IDEs and Editors
+# ==============================================================================
+# VSCode
+.vscode/
+*.code-workspace
+
+# JetBrains
+.idea/
+*.iml
+
+# Vim
+*.swp
+*.swo
+*~
+.netrwhist
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
+# Zed
+.zed/
+
+# ==============================================================================
+# Languages
+# ==============================================================================
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+*.egg-info/
+.eggs/
+*.egg
+.venv/
+venv/
+ENV/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.npm
+.yarn/
+
+# ==============================================================================
+# Environment and Secrets
+# ==============================================================================
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+.envrc
+
+# ==============================================================================
+# Build and Output
+# ==============================================================================
+dist/
+build/
+out/
+*.log

--- a/dotfiles/ssh/config
+++ b/dotfiles/ssh/config
@@ -1,0 +1,86 @@
+# SSH Configuration
+# Symlinked to ~/.ssh/config
+#
+# NOTE: SSH keys should NOT be stored in this repo.
+# Back them up to 1Password: task ssh:backup-1password
+# Restore on new machine: task ssh:restore-1password
+
+# ==============================================================================
+# GitHub Accounts (MUST come before Host * to override global settings)
+# ==============================================================================
+
+# Default GitHub account (saadatqadri)
+Host github.com
+  HostName github.com
+  User git
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519_saadatqadri
+  IdentitiesOnly yes
+  IdentityAgent none
+  ControlPath ~/.ssh/sockets/github-saadatqadri
+  ForwardAgent no
+
+# HeyArchie GitHub account
+Host github-heyarchie
+  HostName github.com
+  User git
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519_heyarchie
+  IdentitiesOnly yes
+  IdentityAgent none
+  ControlPath ~/.ssh/sockets/github-heyarchie
+  ForwardAgent no
+
+# ==============================================================================
+# Global SSH Settings
+# ==============================================================================
+Host *
+  # Connection multiplexing for faster re-connections
+  ControlMaster auto
+  ControlPath ~/.ssh/sockets/%r@%h:%p
+  ControlPersist 10m
+
+  # Connection settings - keep connections alive
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  TCPKeepAlive yes
+
+  # Compression for slower connections
+  Compression yes
+
+  # macOS Keychain integration - stores passphrases permanently
+  AddKeysToAgent yes
+  UseKeychain yes
+
+  # Security settings
+  ForwardAgent no
+  StrictHostKeyChecking ask
+  VerifyHostKeyDNS yes
+
+  # Performance
+  IPQoS throughput
+
+# ==============================================================================
+# Example Configurations (uncomment and customize as needed)
+# ==============================================================================
+
+# Jump Hosts / Bastion
+# Host bastion
+#   HostName bastion.example.com
+#   User your-username
+#   IdentityFile ~/.ssh/id_ed25519
+#   ForwardAgent yes
+
+# Production Servers (via bastion)
+# Host prod-*
+#   User your-username
+#   IdentityFile ~/.ssh/id_ed25519
+#   ProxyJump bastion
+#   ForwardAgent no
+
+# Staging Servers (direct access)
+# Host staging-*
+#   User your-username
+#   IdentityFile ~/.ssh/id_ed25519

--- a/dotfiles/tmux/tmux.conf
+++ b/dotfiles/tmux/tmux.conf
@@ -1,0 +1,168 @@
+# tmux configuration optimized for DevOps and swarm management
+# Symlinked to ~/.tmux.conf
+# Reload config: prefix + r
+
+# ==============================================================================
+# General Settings
+# ==============================================================================
+
+# Use C-a as prefix (easier to reach than C-b)
+unbind C-b
+set-option -g prefix C-a
+bind-key C-a send-prefix
+
+# Reload configuration
+bind r source-file ~/.tmux.conf \; display "Config reloaded!"
+
+# Enable mouse support
+set -g mouse on
+
+# Start windows and panes at 1, not 0
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Renumber windows when one is closed
+set -g renumber-windows on
+
+# Increase scrollback buffer size
+set -g history-limit 50000
+
+# Display tmux messages for 4 seconds
+set -g display-time 4000
+
+# Refresh status bar more frequently (for kubernetes context, etc.)
+set -g status-interval 5
+
+# Focus events enabled for terminals that support them
+set -g focus-events on
+
+# Super useful when using "grouped sessions" and multi-monitor setup
+setw -g aggressive-resize on
+
+# Enable true color support
+set -g default-terminal "screen-256color"
+set -ga terminal-overrides ",xterm-256color:Tc"
+
+# ==============================================================================
+# iTerm2 Integration
+# ==============================================================================
+
+# Enable iTerm2 integration (automatically detects iTerm2)
+set -g allow-passthrough on
+
+# ==============================================================================
+# Key Bindings
+# ==============================================================================
+
+# Split panes using | and -
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# Easy pane navigation with vim keys
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Resize panes with vim keys (with repeat)
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Switch windows with Alt+arrow keys (no prefix needed)
+bind -n M-Left previous-window
+bind -n M-Right next-window
+
+# Create new window in current directory
+bind c new-window -c "#{pane_current_path}"
+
+# Quick session switcher
+bind C-j choose-session
+
+# Copy mode vim bindings
+setw -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+
+# ==============================================================================
+# Status Bar
+# ==============================================================================
+
+# Status bar styling for DevOps work
+set -g status-position bottom
+set -g status-justify left
+set -g status-style 'bg=#1e1e1e fg=#00d787'
+
+# Left side: session name and hostname
+set -g status-left-length 40
+set -g status-left '#[fg=#00d787,bg=#262626,bold] #S #[fg=#87afff]@ #H '
+
+# Right side: kubernetes context, date, time
+set -g status-right-length 100
+set -g status-right '#[fg=#ffd787]☸ #(kubectl config current-context 2>/dev/null || echo "no-ctx") #[fg=#87afff]| %Y-%m-%d #[fg=#00d787]| %H:%M:%S '
+
+# Window status styling
+setw -g window-status-current-style 'fg=#1e1e1e bg=#00d787 bold'
+setw -g window-status-current-format ' #I:#W#F '
+
+setw -g window-status-style 'fg=#87afff bg=#262626'
+setw -g window-status-format ' #I:#W#F '
+
+# Pane border colors
+set -g pane-border-style 'fg=#444444'
+set -g pane-active-border-style 'fg=#00d787'
+
+# Message styling
+set -g message-style 'fg=#1e1e1e bg=#00d787 bold'
+
+# ==============================================================================
+# Session Management
+# ==============================================================================
+
+# Automatically restore sessions (requires tmux-resurrect)
+# Install with: git clone https://github.com/tmux-plugins/tmux-resurrect ~/.tmux/plugins/tmux-resurrect
+
+# Session save/restore shortcuts
+# prefix + Ctrl-s - save session
+# prefix + Ctrl-r - restore session
+
+# ==============================================================================
+# Docker Swarm Helpers
+# ==============================================================================
+
+# Quick access to docker swarm commands
+bind-key D command-prompt -p "Docker Node:" "split-window -h 'ssh %% \"docker node ls\"'"
+bind-key S command-prompt -p "Service Name:" "split-window -h 'docker service logs -f %%'"
+
+# ==============================================================================
+# Kubernetes Helpers
+# ==============================================================================
+
+# Quick kubectl commands
+bind-key P command-prompt -p "Pod Name:" "split-window -h 'kubectl logs -f %%'"
+bind-key N command-prompt -p "Namespace:" "split-window -h 'kubectl get pods -n %%'"
+
+# ==============================================================================
+# Plugin Manager (TPM)
+# ==============================================================================
+
+# List of plugins
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# Plugin settings
+set -g @resurrect-strategy-vim 'session'
+set -g @resurrect-strategy-nvim 'session'
+set -g @resurrect-capture-pane-contents 'on'
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+
+# Initialize TPM (keep this line at the very bottom)
+# Install TPM with: git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+run '~/.tmux/plugins/tpm/tpm'

--- a/dotfiles/zed/settings.json
+++ b/dotfiles/zed/settings.json
@@ -1,0 +1,40 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "assistant": {
+    "default_model": {
+      "provider": "anthropic",
+      "model": "claude-3-5-sonnet-latest"
+    },
+    "version": "2"
+  },
+  "ui_font_size": 14,
+  "buffer_font_size": 14,
+  "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "One Light"
+  },
+  "languages": {
+    "Python": {
+      "language_servers": ["ruff"],
+      "format_on_save": "on",
+      "formatter": [
+        {
+          "code_actions": {
+            // Fix all auto-fixable lint violations
+            "source.fixAll.ruff": true,
+            // Organize imports
+            "source.organizeImports.ruff": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/dotfiles/zsh/p10k.zsh
+++ b/dotfiles/zsh/p10k.zsh
@@ -1,0 +1,89 @@
+# Powerlevel10k instant prompt configuration
+# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
+# Powerlevel10k prompt segments configuration
+typeset -g POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(
+  dir                     # current directory
+  vcs                     # git status
+  kubecontext             # kubernetes context
+  context                 # user@host when relevant
+  command_execution_time  # duration of the last command
+  newline                 # line break
+  prompt_char             # prompt symbol
+)
+
+typeset -g POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(
+  status                  # exit code of the last command
+  background_jobs         # presence of background jobs
+  direnv                  # direnv status
+  virtualenv              # python virtual environment
+  nodenv                  # node version
+  time                    # current time
+)
+
+# Kubernetes context styling
+typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|k9s'
+typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_DEFAULT_NAMESPACE=true
+typeset -g POWERLEVEL9K_KUBECONTEXT_FOREGROUND=134
+typeset -g POWERLEVEL9K_KUBECONTEXT_PRODUCTION_FOREGROUND=1
+typeset -g POWERLEVEL9K_KUBECONTEXT_PRODUCTION_BACKGROUND=235
+typeset -g POWERLEVEL9K_KUBECONTEXT_PRODUCTION_CONTENT_EXPANSION='%F{red}☸ ${P9K_KUBECONTEXT_NAMESPACE}%f'
+
+# Context (user@host) styling
+typeset -g POWERLEVEL9K_CONTEXT_FOREGROUND=180
+typeset -g POWERLEVEL9K_CONTEXT_ROOT_FOREGROUND=227
+typeset -g POWERLEVEL9K_CONTEXT_TEMPLATE='%n@%m'
+typeset -g POWERLEVEL9K_CONTEXT_{DEFAULT,SUDO}_{CONTENT,VISUAL_IDENTIFIER}_EXPANSION=
+
+# Show context only when in SSH or sudo
+typeset -g POWERLEVEL9K_CONTEXT_ROOT_TEMPLATE='%F{red}%n@%m%f'
+
+# Command execution time
+typeset -g POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=3
+typeset -g POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=2
+typeset -g POWERLEVEL9K_COMMAND_EXECUTION_TIME_FOREGROUND=220
+
+# Directory styling
+typeset -g POWERLEVEL9K_DIR_FOREGROUND=31
+typeset -g POWERLEVEL9K_SHORTEN_STRATEGY=truncate_to_unique
+typeset -g POWERLEVEL9K_SHORTEN_DELIMITER=
+typeset -g POWERLEVEL9K_DIR_SHORTENED_FOREGROUND=103
+typeset -g POWERLEVEL9K_DIR_ANCHOR_FOREGROUND=39
+typeset -g POWERLEVEL9K_DIR_ANCHOR_BOLD=true
+
+# Git styling
+typeset -g POWERLEVEL9K_VCS_CLEAN_FOREGROUND=76
+typeset -g POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND=76
+typeset -g POWERLEVEL9K_VCS_MODIFIED_FOREGROUND=178
+
+# Prompt character
+typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_{VIINS,VICMD,VIVIS,VIOWR}_FOREGROUND=76
+typeset -g POWERLEVEL9K_PROMPT_CHAR_ERROR_{VIINS,VICMD,VIVIS,VIOWR}_FOREGROUND=196
+typeset -g POWERLEVEL9K_PROMPT_CHAR_{OK,ERROR}_VIINS_CONTENT_EXPANSION='❯'
+typeset -g POWERLEVEL9K_PROMPT_CHAR_{OK,ERROR}_VICMD_CONTENT_EXPANSION='❮'
+
+# Status
+typeset -g POWERLEVEL9K_STATUS_ERROR=true
+typeset -g POWERLEVEL9K_STATUS_ERROR_FOREGROUND=196
+
+# Background jobs
+typeset -g POWERLEVEL9K_BACKGROUND_JOBS_FOREGROUND=37
+
+# Time
+typeset -g POWERLEVEL9K_TIME_FOREGROUND=66
+typeset -g POWERLEVEL9K_TIME_FORMAT='%D{%H:%M:%S}'
+
+# Transient prompt
+typeset -g POWERLEVEL9K_TRANSIENT_PROMPT=always
+typeset -g POWERLEVEL9K_INSTANT_PROMPT=verbose
+
+# Color palette optimized for DevOps work
+typeset -g POWERLEVEL9K_MODE='nerdfont-complete'
+typeset -g POWERLEVEL9K_ICON_PADDING=moderate
+typeset -g POWERLEVEL9K_PROMPT_ADD_NEWLINE=true
+typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_GAP_CHAR='·'
+typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='%244F\uE0B1'
+typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='%244F\uE0B3'

--- a/dotfiles/zsh/zshrc
+++ b/dotfiles/zsh/zshrc
@@ -1,0 +1,461 @@
+# If you come from bash you might have to change your $PATH.
+# export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
+
+# Path to your Oh My Zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time Oh My Zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
+ZSH_THEME="powerlevel10k/powerlevel10k"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in $ZSH/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
+# HYPHEN_INSENSITIVE="true"
+
+# Uncomment one of the following lines to change the auto-update behavior
+# zstyle ':omz:update' mode disabled  # disable automatic updates
+# zstyle ':omz:update' mode auto      # update automatically without asking
+# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
+
+# Uncomment the following line to change how often to auto-update (in days).
+# zstyle ':omz:update' frequency 13
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS="true"
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# You can also set it to another string to have that shown instead of the default red dots.
+# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
+# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+# DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+plugins=(
+  git
+  docker
+  docker-compose
+  kubectl
+  command-not-found
+  colored-man-pages
+  zsh-autosuggestions
+  zsh-syntax-highlighting
+)
+
+source $ZSH/oh-my-zsh.sh
+
+# User configuration
+
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='nvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch $(uname -m)"
+
+# Set personal aliases, overriding those provided by Oh My Zsh libs,
+# plugins, and themes. Aliases can be placed here, though Oh My Zsh
+# users are encouraged to define aliases within a top-level file in
+# the $ZSH_CUSTOM folder, with .zsh extension. Examples:
+# - $ZSH_CUSTOM/aliases.zsh
+# - $ZSH_CUSTOM/macos.zsh
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"
+
+
+export NVM_DIR="$HOME/.nvm"
+    [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" # This loads nvm
+    [ -s "$HOMEBREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm" ] && \. "$HOMEBREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm" # This loads nvm bash_completion
+
+# Added by Windsurf
+export PATH="/Users/sqadri/.codeium/windsurf/bin:$PATH"
+
+# GPG TTY setup for signing commits
+export GPG_TTY=$(tty)
+
+. "$HOME/.local/bin/env"
+export PATH="$HOME/.dotnet:$PATH"
+
+# pnpm
+export PNPM_HOME="/Users/sqadri/Library/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+# pnpm end
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# --- Quick repo root navigation (zsh) ---
+# Jump to the current git repository root
+root() {
+  local r
+  r=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not inside a git repository."
+    return 1
+  }
+  builtin cd "$r" || return
+}
+
+# cd to a path relative to the repo root
+# Usage: rt [sub/path]
+rt() {
+  local r
+  r=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not inside a git repository."
+    return 1
+  }
+  if [ $# -eq 0 ]; then
+    builtin cd "$r" || return
+  else
+    builtin cd "$r/$*" || return
+  fi
+}
+
+# Convenience: cd to an app folder under common roots
+# Tries: apps/<name>, app/<name>, services/<name>, packages/<name>, or <name>
+# Usage: app <name>
+app() {
+  if [ $# -eq 0 ]; then
+    echo "Usage: app <name>"
+    return 2
+  fi
+  local r
+  r=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not inside a git repository."
+    return 1
+  }
+  local -a candidates
+  candidates=(
+    "apps/$1"
+    "app/$1"
+    "services/$1"
+    "packages/$1"
+    "$1"
+  )
+  local p target=""
+  for p in "${candidates[@]}"; do
+    if [ -d "$r/$p" ]; then
+      target="$r/$p"
+      break
+    fi
+  done
+  if [ -n "$target" ]; then
+    builtin cd "$target" || return
+  else
+    echo "No matching app folder for '$1' under $r"
+    return 1
+  fi
+}
+
+# Short alias
+alias r='root'
+
+# Powerlevel10k configuration
+[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+
+# ==================== DevOps Aliases & Functions ====================
+
+# -------------------- Docker & Docker Compose --------------------
+alias d='docker'
+alias dc='docker-compose'
+alias dps='docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'
+alias dpsa='docker ps -a --format "table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'
+alias di='docker images'
+alias dex='docker exec -it'
+alias dlog='docker logs -f'
+alias dprune='docker system prune -af --volumes'
+alias dstop='docker stop $(docker ps -q)'
+
+# Docker Swarm
+alias dsw='docker swarm'
+alias dsn='docker service'
+alias dsl='docker service ls'
+alias dsps='docker service ps'
+alias dslogs='docker service logs -f'
+alias dscale='docker service scale'
+alias dstack='docker stack'
+alias dstls='docker stack ls'
+alias dstps='docker stack ps'
+alias dstrm='docker stack rm'
+
+# Docker cleanup functions
+dclean() {
+  echo "Removing stopped containers..."
+  docker container prune -f
+  echo "Removing dangling images..."
+  docker image prune -f
+  echo "Removing unused networks..."
+  docker network prune -f
+  echo "Removing unused volumes..."
+  docker volume prune -f
+}
+
+# Exec into container by partial name
+dsh() {
+  if [ -z "$1" ]; then
+    echo "Usage: dsh <container-name-or-id>"
+    return 1
+  fi
+  local container=$(docker ps --format '{{.Names}}' | grep "$1" | head -1)
+  if [ -z "$container" ]; then
+    echo "No running container found matching: $1"
+    return 1
+  fi
+  echo "Connecting to: $container"
+  docker exec -it "$container" /bin/sh -c 'command -v bash >/dev/null && exec bash || exec sh'
+}
+
+# -------------------- Kubernetes --------------------
+alias k='kubectl'
+alias kgp='kubectl get pods'
+alias kgs='kubectl get services'
+alias kgd='kubectl get deployments'
+alias kgn='kubectl get nodes'
+alias kd='kubectl describe'
+alias kdp='kubectl describe pod'
+alias kl='kubectl logs'
+alias klf='kubectl logs -f'
+alias kex='kubectl exec -it'
+alias kaf='kubectl apply -f'
+alias kdf='kubectl delete -f'
+alias kctx='kubectl config current-context'
+alias kns='kubectl config set-context --current --namespace'
+
+# Get all resources in namespace
+kgetall() {
+  local ns=${1:-default}
+  echo "Getting all resources in namespace: $ns"
+  kubectl get all -n "$ns"
+}
+
+# Quick pod shell access
+ksh() {
+  if [ -z "$1" ]; then
+    echo "Usage: ksh <pod-name> [container-name]"
+    return 1
+  fi
+  if [ -n "$2" ]; then
+    kubectl exec -it "$1" -c "$2" -- /bin/sh -c 'command -v bash >/dev/null && exec bash || exec sh'
+  else
+    kubectl exec -it "$1" -- /bin/sh -c 'command -v bash >/dev/null && exec bash || exec sh'
+  fi
+}
+
+# Watch pods in current namespace
+kwatch() {
+  watch -n 2 "kubectl get pods ${1:+ -l $1} | grep -E '(NAME|Running|Error|CrashLoop|Pending|Terminating)'"
+}
+
+# Port forward helper (unalias kubectl plugin's kpf first)
+unalias kpf 2>/dev/null
+kpf() {
+  if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: kpf <pod-name> <port>"
+    return 1
+  fi
+  kubectl port-forward "$1" "$2:$2"
+}
+
+# Switch kubernetes context quickly
+kuse() {
+  if [ -z "$1" ]; then
+    kubectl config get-contexts
+  else
+    kubectl config use-context "$1"
+  fi
+}
+
+# -------------------- Git --------------------
+alias gs='git status'
+alias ga='git add'
+alias gaa='git add .'
+alias gc='git commit -m'
+alias gca='git commit --amend'
+alias gp='git push'
+alias gpl='git pull'
+alias gf='git fetch'
+alias gb='git branch'
+alias gco='git checkout'
+alias gcb='git checkout -b'
+alias gd='git diff'
+alias gds='git diff --staged'
+alias gl='git log --oneline --graph --decorate -10'
+alias gla='git log --oneline --graph --decorate --all'
+
+# -------------------- System Monitoring --------------------
+alias ports='lsof -i -P -n | grep LISTEN'
+alias myip='curl -s https://api.ipify.org && echo'
+alias localip='ipconfig getifaddr en0'
+
+# Process monitoring
+alias psg='ps aux | grep -v grep | grep -i -e VSZ -e'
+alias memtop='top -o MEM'
+alias cputop='top -o CPU'
+
+# -------------------- tmux --------------------
+alias t='tmux'
+alias ta='tmux attach -t'
+alias tl='tmux list-sessions'
+alias tn='tmux new -s'
+alias tk='tmux kill-session -t'
+
+# Quick tmux session for project
+tproj() {
+  if [ -z "$1" ]; then
+    echo "Usage: tproj <session-name>"
+    return 1
+  fi
+  tmux new-session -d -s "$1"
+  tmux send-keys -t "$1" "cd $PWD" C-m
+  tmux attach -t "$1"
+}
+
+# -------------------- SSH & Network --------------------
+# Quick SSH with tmux
+ssht() {
+  if [ -z "$1" ]; then
+    echo "Usage: ssht <host>"
+    return 1
+  fi
+  ssh "$1" -t "tmux attach || tmux new"
+}
+
+# Test port connectivity
+testport() {
+  if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: testport <host> <port>"
+    return 1
+  fi
+  nc -zv "$1" "$2"
+}
+
+# -------------------- File Operations --------------------
+alias ll='ls -lah'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Quick navigation
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+
+# Make directory and cd into it
+mkcd() {
+  mkdir -p "$1" && cd "$1"
+}
+
+# -------------------- Archie Platform Specific --------------------
+# Navigate to archie platform
+alias archie='cd /Users/sqadri/client-work/archie/archie-platform-v2'
+
+# Quick service navigation within archie
+svc() {
+  if [ -z "$1" ]; then
+    echo "Usage: svc <service-name>"
+    echo "Available services:"
+    ls -d /Users/sqadri/client-work/archie/archie-platform-v2/services/* 2>/dev/null | xargs -n 1 basename
+    return 1
+  fi
+  cd "/Users/sqadri/client-work/archie/archie-platform-v2/services/$1" 2>/dev/null || echo "Service not found: $1"
+}
+
+# -------------------- Development Helpers --------------------
+# Find and kill process by port
+killport() {
+  if [ -z "$1" ]; then
+    echo "Usage: killport <port>"
+    return 1
+  fi
+  lsof -ti:"$1" | xargs kill -9
+}
+
+# Quick HTTP server
+serve() {
+  local port=${1:-8000}
+  python3 -m http.server "$port"
+}
+
+# -------------------- Environment Info --------------------
+# Show current DevOps context
+devinfo() {
+  echo "=== DevOps Environment Info ==="
+  echo ""
+  echo "Kubernetes Context: $(kubectl config current-context 2>/dev/null || echo 'Not configured')"
+  echo "Kubernetes Namespace: $(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null || echo 'default')"
+  echo ""
+  echo "Docker:"
+  docker version --format '  Client: {{.Client.Version}}  Server: {{.Server.Version}}' 2>/dev/null || echo "  Not running"
+  echo ""
+  echo "Docker Swarm:"
+  docker info --format '  Status: {{.Swarm.LocalNodeState}}' 2>/dev/null || echo "  Not active"
+  echo ""
+  echo "Git Branch: $(git branch --show-current 2>/dev/null || echo 'Not in a git repo')"
+  echo "Git Remote: $(git remote get-url origin 2>/dev/null || echo 'No remote')"
+  echo ""
+  echo "Node: $(node --version 2>/dev/null || echo 'Not installed')"
+  echo "npm: $(npm --version 2>/dev/null || echo 'Not installed')"
+  echo "pnpm: $(pnpm --version 2>/dev/null || echo 'Not installed')"
+}
+
+# -------------------- Auto-completions --------------------
+# kubectl completion (if not already loaded by plugin)
+if command -v kubectl &> /dev/null; then
+  source <(kubectl completion zsh)
+  complete -F __start_kubectl k
+fi
+
+# docker completion (if not already loaded by plugin)
+if command -v docker &> /dev/null; then
+  # macOS specific docker completion location
+  [ -f /Applications/Docker.app/Contents/Resources/etc/docker.zsh-completion ] && source /Applications/Docker.app/Contents/Resources/etc/docker.zsh-completion
+fi

--- a/init.sh
+++ b/init.sh
@@ -1,84 +1,26 @@
 #!/bin/bash
-set -e  # Exit on error
+# Legacy wrapper - use 'task' commands instead
+# See: task --list
 
-# Get the directory of the script
+set -e
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BREWFILE_PATH="${SCRIPT_DIR}/Brewfile"
+cd "$SCRIPT_DIR"
 
-# =============================================================================
-# HOMEBREW
-# =============================================================================
+# Check if go-task is installed
+if ! command -v task &> /dev/null; then
+    echo "go-task not found. Installing via Homebrew..."
 
-# Install Homebrew if not present
-if ! command -v brew &> /dev/null; then
-    echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    # Add Homebrew to PATH for Apple Silicon
-    if [[ $(uname -m) == "arm64" ]]; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
+    # Install Homebrew if needed
+    if ! command -v brew &> /dev/null; then
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        if [[ $(uname -m) == "arm64" ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
     fi
+
+    brew install go-task
 fi
 
-echo "Updating Homebrew..."
-brew update
-
-echo "Upgrading installed formulae..."
-brew upgrade
-
-echo "Installing from Brewfile..."
-brew bundle --file "${BREWFILE_PATH}"
-
-echo "Cleaning up unlisted applications..."
-brew bundle cleanup --force --file "${BREWFILE_PATH}"
-
-echo "Verifying Brewfile state..."
-brew bundle check --file "${BREWFILE_PATH}"
-
-# =============================================================================
-# OH-MY-ZSH (idempotent)
-# =============================================================================
-
-if [ ! -d "$HOME/.oh-my-zsh" ]; then
-    echo "Installing oh-my-zsh..."
-    sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-else
-    echo "oh-my-zsh already installed, skipping..."
-fi
-
-# =============================================================================
-# GIT CONFIGURATION
-# =============================================================================
-
-echo "Configuring git..."
-git config --global user.name "Saadat Qadri"
-git config --global user.email "saadat.qadri@gmail.com"
-git config --global init.defaultBranch main
-git config --global core.editor "code --wait"
-git config --global credential.helper cache
-git config --global user.signingkey 3CD5D6A0B9B8F207
-git config --global commit.gpgsign true
-
-# =============================================================================
-# CLAUDE CODE (requires npm from node)
-# =============================================================================
-
-if ! command -v claude &> /dev/null; then
-    echo "Installing Claude Code..."
-    npm install -g @anthropic-ai/claude-code
-else
-    echo "Claude Code already installed, checking for updates..."
-    npm update -g @anthropic-ai/claude-code
-fi
-
-# =============================================================================
-# DONE
-# =============================================================================
-
-echo ""
-echo "Initialization complete!"
-echo ""
-echo "Next steps:"
-echo "  1. Open 1Password and sign in"
-echo "  2. Run 'claude' to authenticate Claude Code with your Anthropic API key"
-echo "  3. Import your GPG keys for git commit signing"
+# Run the full setup
+task all

--- a/init.sh
+++ b/init.sh
@@ -1,45 +1,84 @@
 #!/bin/bash
+set -e  # Exit on error
 
 # Get the directory of the script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Path to the Brewfile in the same directory as the script
 BREWFILE_PATH="${SCRIPT_DIR}/Brewfile"
 
-# Update Homebrew and all formulas.
+# =============================================================================
+# HOMEBREW
+# =============================================================================
+
+# Install Homebrew if not present
+if ! command -v brew &> /dev/null; then
+    echo "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Add Homebrew to PATH for Apple Silicon
+    if [[ $(uname -m) == "arm64" ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
+fi
+
 echo "Updating Homebrew..."
 brew update
 
-# Upgrade any already-installed formulae.
 echo "Upgrading installed formulae..."
 brew upgrade
 
-# Install or check dependencies from the Brewfile located at the user's home directory.
-echo "Checking for new applications or mismatches..."
+echo "Installing from Brewfile..."
 brew bundle --file "${BREWFILE_PATH}"
 
-# Cleanup anything that is not listed in the Brewfile.
 echo "Cleaning up unlisted applications..."
 brew bundle cleanup --force --file "${BREWFILE_PATH}"
 
-# Check if everything is in sync.
 echo "Verifying Brewfile state..."
-# Run brew bundle check with the specified Brewfile
 brew bundle check --file "${BREWFILE_PATH}"
 
-echo "Initialization complete."
+# =============================================================================
+# OH-MY-ZSH (idempotent)
+# =============================================================================
 
-# oh-my-zsh (not really idempotent)
-sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+    echo "Installing oh-my-zsh..."
+    sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+else
+    echo "oh-my-zsh already installed, skipping..."
+fi
 
-# git setup
+# =============================================================================
+# GIT CONFIGURATION
+# =============================================================================
 
+echo "Configuring git..."
 git config --global user.name "Saadat Qadri"
+git config --global user.email "saadat.qadri@gmail.com"
 git config --global init.defaultBranch main
 git config --global core.editor "code --wait"
 git config --global credential.helper cache
 git config --global user.signingkey 3CD5D6A0B9B8F207
 git config --global commit.gpgsign true
 
-# install poetry
-curl -sSL https://install.python-poetry.org | python3 -
+# =============================================================================
+# CLAUDE CODE (requires npm from node)
+# =============================================================================
+
+if ! command -v claude &> /dev/null; then
+    echo "Installing Claude Code..."
+    npm install -g @anthropic-ai/claude-code
+else
+    echo "Claude Code already installed, checking for updates..."
+    npm update -g @anthropic-ai/claude-code
+fi
+
+# =============================================================================
+# DONE
+# =============================================================================
+
+echo ""
+echo "Initialization complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Open 1Password and sign in"
+echo "  2. Run 'claude' to authenticate Claude Code with your Anthropic API key"
+echo "  3. Import your GPG keys for git commit signing"

--- a/scripts/macos-defaults.sh
+++ b/scripts/macos-defaults.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# macOS Defaults - Sensible defaults for a development machine
+# Run: ./scripts/macos-defaults.sh
+# Some changes require logout/restart to take effect
+
+set -e
+
+echo "Setting macOS defaults..."
+
+# Close System Preferences to prevent overriding changes
+osascript -e 'tell application "System Preferences" to quit' 2>/dev/null || true
+
+# ==============================================================================
+# KEYBOARD (your current: KeyRepeat=2, InitialKeyRepeat=15 - very fast!)
+# ==============================================================================
+echo "Configuring keyboard..."
+
+# Fast key repeat (lower = faster, yours is already at 2 which is great)
+defaults write NSGlobalDomain KeyRepeat -int 2
+
+# Short delay before repeat starts (lower = shorter, yours is 15)
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
+
+# Disable press-and-hold for accented characters (enables key repeat everywhere)
+defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+
+# Disable auto-correct
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+
+# Disable automatic capitalization
+defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+
+# Disable smart dashes
+defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+
+# Disable smart quotes
+defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+
+# Disable auto period substitution
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+
+# ==============================================================================
+# DOCK (your current: autohide=1, tilesize=50)
+# ==============================================================================
+echo "Configuring Dock..."
+
+# Enable auto-hide
+defaults write com.apple.dock autohide -bool true
+
+# Remove auto-hide delay
+defaults write com.apple.dock autohide-delay -float 0
+
+# Faster auto-hide animation
+defaults write com.apple.dock autohide-time-modifier -float 0.3
+
+# Set dock icon size
+defaults write com.apple.dock tilesize -int 50
+
+# Don't show recent applications in Dock
+defaults write com.apple.dock show-recents -bool false
+
+# Minimize windows into application icon
+defaults write com.apple.dock minimize-to-application -bool true
+
+# Don't animate opening applications
+defaults write com.apple.dock launchanim -bool false
+
+# Speed up Mission Control animations
+defaults write com.apple.dock expose-animation-duration -float 0.1
+
+# ==============================================================================
+# FINDER (your current: AppleShowAllFiles=1)
+# ==============================================================================
+echo "Configuring Finder..."
+
+# Show hidden files
+defaults write com.apple.finder AppleShowAllFiles -bool true
+
+# Show all filename extensions
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+
+# Show path bar at bottom
+defaults write com.apple.finder ShowPathbar -bool true
+
+# Show status bar
+defaults write com.apple.finder ShowStatusBar -bool true
+
+# Keep folders on top when sorting by name
+defaults write com.apple.finder _FXSortFoldersFirst -bool true
+
+# Search current folder by default (not entire Mac)
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+
+# Disable warning when changing file extension
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+
+# Avoid creating .DS_Store on network volumes
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+
+# Avoid creating .DS_Store on USB volumes
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+
+# Show icons for hard drives, servers, and removable media on desktop
+defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool true
+defaults write com.apple.finder ShowMountedServersOnDesktop -bool true
+defaults write com.apple.finder ShowRemovableMediaOnDesktop -bool true
+
+# Use list view in all Finder windows by default
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
+
+# Expand save panel by default
+defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true
+defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode2 -bool true
+
+# Expand print panel by default
+defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool true
+defaults write NSGlobalDomain PMPrintingExpandedStateForPrint2 -bool true
+
+# ==============================================================================
+# SCREENSHOTS
+# ==============================================================================
+echo "Configuring screenshots..."
+
+# Create screenshots directory
+mkdir -p ~/Screenshots
+
+# Save screenshots to ~/Screenshots
+defaults write com.apple.screencapture location -string "${HOME}/Screenshots"
+
+# Save screenshots as PNG
+defaults write com.apple.screencapture type -string "png"
+
+# Disable shadow in screenshots
+defaults write com.apple.screencapture disable-shadow -bool true
+
+# ==============================================================================
+# TRACKPAD & MOUSE
+# ==============================================================================
+echo "Configuring trackpad..."
+
+# Enable tap to click
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
+defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
+
+# Enable three finger drag
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool true
+
+# Increase tracking speed (1-3, higher = faster)
+defaults write NSGlobalDomain com.apple.trackpad.scaling -float 2.0
+
+# ==============================================================================
+# SAFARI (if you use it)
+# ==============================================================================
+echo "Configuring Safari..."
+
+# Don't open "safe" files automatically
+defaults write com.apple.Safari AutoOpenSafeDownloads -bool false
+
+# Enable developer menu and web inspector
+defaults write com.apple.Safari IncludeDevelopMenu -bool true
+defaults write com.apple.Safari WebKitDeveloperExtrasEnabledPreferenceKey -bool true
+
+# ==============================================================================
+# TERMINAL
+# ==============================================================================
+echo "Configuring Terminal..."
+
+# Only use UTF-8 in Terminal.app
+defaults write com.apple.terminal StringEncodings -array 4
+
+# Enable Secure Keyboard Entry in Terminal
+defaults write com.apple.terminal SecureKeyboardEntry -bool true
+
+# ==============================================================================
+# ACTIVITY MONITOR
+# ==============================================================================
+echo "Configuring Activity Monitor..."
+
+# Show all processes
+defaults write com.apple.ActivityMonitor ShowCategory -int 0
+
+# Sort by CPU usage
+defaults write com.apple.ActivityMonitor SortColumn -string "CPUUsage"
+defaults write com.apple.ActivityMonitor SortDirection -int 0
+
+# ==============================================================================
+# TEXT EDIT
+# ==============================================================================
+echo "Configuring TextEdit..."
+
+# Use plain text mode by default
+defaults write com.apple.TextEdit RichText -int 0
+
+# Open and save files as UTF-8
+defaults write com.apple.TextEdit PlainTextEncoding -int 4
+defaults write com.apple.TextEdit PlainTextEncodingForWrite -int 4
+
+# ==============================================================================
+# MISC SYSTEM PREFERENCES
+# ==============================================================================
+echo "Configuring system preferences..."
+
+# Disable the "Are you sure you want to open this application?" dialog
+defaults write com.apple.LaunchServices LSQuarantine -bool false
+
+# Disable Resume system-wide
+defaults write com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false
+
+# Disable automatic termination of inactive apps
+defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true
+
+# Disable the crash reporter
+defaults write com.apple.CrashReporter DialogType -string "none"
+
+# ==============================================================================
+# ENERGY & PERFORMANCE
+# ==============================================================================
+echo "Configuring energy settings..."
+
+# Never go into computer sleep mode (when on power adapter)
+sudo pmset -c displaysleep 15 sleep 0 disksleep 0 2>/dev/null || true
+
+# ==============================================================================
+# RESTART AFFECTED APPLICATIONS
+# ==============================================================================
+echo ""
+echo "Restarting affected applications..."
+
+for app in "Activity Monitor" "Dock" "Finder" "Safari" "SystemUIServer"; do
+  killall "${app}" &> /dev/null || true
+done
+
+echo ""
+echo "Done! Some changes require logout/restart to take effect."
+echo ""
+echo "Key settings applied:"
+echo "  - Fast key repeat (KeyRepeat=2, InitialKeyRepeat=15)"
+echo "  - Dock: auto-hide, size 50, no recents"
+echo "  - Finder: show hidden files, extensions, path bar"
+echo "  - Screenshots saved to ~/Screenshots"
+echo "  - Trackpad: tap to click, three finger drag"

--- a/scripts/ssh-backup-1password.md
+++ b/scripts/ssh-backup-1password.md
@@ -1,0 +1,143 @@
+# SSH Key Backup with 1Password
+
+## Why Back Up SSH Keys?
+
+SSH keys are machine-specific credentials. You have two options when setting up a new Mac:
+
+1. **Generate fresh keys (recommended)** - Better security, easier to revoke per-device
+2. **Restore from backup** - Immediate access, no need to update GitHub/servers
+
+## Quick Backup with 1Password CLI
+
+The fastest way to back up your SSH keys:
+
+```bash
+# One-time setup: enable CLI integration in 1Password app
+# Settings > Developer > "Integrate with 1Password CLI"
+
+# Back up all SSH keys at once
+task ssh:backup-1password
+
+# Or manually back up a specific key
+op item create \
+  --category="Secure Note" \
+  --title="SSH Key - Personal GitHub" \
+  --vault="Private" \
+  'private_key[password]'="$(cat ~/.ssh/id_ed25519)" \
+  'public_key[text]'="$(cat ~/.ssh/id_ed25519.pub)" \
+  'notes[text]'="Backed up from $(hostname) on $(date)"
+```
+
+## Restore from 1Password CLI
+
+```bash
+# List your SSH key backups
+op item list --categories "Secure Note" | grep "SSH Key"
+
+# Restore a key
+op item get "SSH Key - Personal GitHub" --fields private_key > ~/.ssh/id_ed25519
+op item get "SSH Key - Personal GitHub" --fields public_key > ~/.ssh/id_ed25519.pub
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+ssh-add ~/.ssh/id_ed25519
+```
+
+## Backing Up to 1Password
+
+### Option 1: Using 1Password SSH Agent (Recommended)
+
+1Password can generate and manage SSH keys directly, syncing them across devices:
+
+1. Open 1Password > Settings > Developer
+2. Enable "Use the SSH Agent"
+3. Create a new SSH key in 1Password:
+   - Click + > SSH Key
+   - Name it (e.g., "Personal GitHub" or "Work SSH")
+   - 1Password generates the key securely
+4. Add public key to GitHub/servers as usual
+5. Configure SSH to use 1Password agent:
+
+```bash
+# Add to ~/.ssh/config (this is already handled in the dotfiles)
+Host *
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+```
+
+### Option 2: Manual Backup (for existing keys)
+
+Store your existing SSH keys in 1Password as secure notes or documents:
+
+1. **For each key pair**, create a new Secure Note in 1Password:
+   - Title: "SSH Key - [description]" (e.g., "SSH Key - Personal GitHub")
+   - Add the private key content as a field or attachment
+   - Add the public key content
+   - Add passphrase if the key has one
+
+2. **Backup commands**:
+```bash
+# View your public key (safe to share)
+cat ~/.ssh/id_ed25519.pub
+
+# View your private key (KEEP SECRET)
+cat ~/.ssh/id_ed25519
+
+# Copy private key to clipboard for pasting into 1Password
+pbcopy < ~/.ssh/id_ed25519
+```
+
+3. **Your current keys to back up**:
+   - `~/.ssh/id_ed25519` (personal)
+   - `~/.ssh/id_ed25519_heyarchie` (work)
+   - `~/.ssh/archie_id_ed25519` (archie)
+   - `~/.ssh/id_rsa` (legacy RSA key)
+
+## Restoring on a New Mac
+
+### From 1Password SSH Agent
+
+If using 1Password's SSH agent, keys sync automatically. Just:
+
+1. Install 1Password
+2. Sign in
+3. Enable SSH Agent in Developer settings
+4. Keys are available immediately
+
+### From Manual Backup
+
+```bash
+# Create .ssh directory with correct permissions
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+
+# Paste private key from 1Password and save
+# Then set correct permissions
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+
+# Add to SSH agent
+ssh-add ~/.ssh/id_ed25519
+```
+
+## Generating Fresh Keys (Alternative)
+
+If you prefer fresh keys per machine:
+
+```bash
+# Generate new ed25519 key (recommended algorithm)
+ssh-keygen -t ed25519 -C "saadat.qadri@gmail.com"
+
+# Add to GitHub
+gh ssh-key add ~/.ssh/id_ed25519.pub --title "MacBook Pro $(date +%Y)"
+
+# Or copy and add manually
+pbcopy < ~/.ssh/id_ed25519.pub
+# Then go to https://github.com/settings/keys
+```
+
+## Security Best Practices
+
+1. **Always use a passphrase** on your SSH keys
+2. **Use ed25519 keys** (more secure than RSA)
+3. **Don't commit keys to git** (they're in .gitignore)
+4. **Regularly audit** which keys have access to your servers
+5. **Revoke old keys** when decommissioning machines


### PR DESCRIPTION
## Summary

- Reorganize Brewfile for AI development workflows (add uv, gh, jq; remove transitive deps; replace VS Code with Zed)
- Add dotfiles management with symlinks for zsh (zshrc, p10k) and Zed configs
- Migrate from monolithic init.sh to modular go-task with 20 tasks
- Add comprehensive README with documentation

## Changes

**Brewfile**
- Added: `uv`, `gh`, `jq`, `cmake`, `wget`, `zed`
- Removed: `icu4c@77`, `libnghttp2`, `python@3.9`, `python@3.13`, `visual-studio-code`
- Organized into clear sections (Core, Node.js, Python/AI, Data, Cloud, Dev Tools, Apps)

**Taskfile.yml** (new)
- `task all` - Full setup
- `task brew` - Homebrew packages
- `task dotfiles` - Symlink configs
- `task zsh-plugins` - oh-my-zsh, p10k, autosuggestions, syntax-highlighting
- `task git` - Git configuration
- `task claude` - Claude Code installation
- `task status` - Show current state

**dotfiles/** (new)
- `zsh/zshrc` - Full zsh config with DevOps aliases
- `zsh/p10k.zsh` - Powerlevel10k theme
- `zed/settings.json` - Zed editor settings

## Test plan

- [ ] Run `task --list` to verify Taskfile parses correctly
- [ ] Run `task status` to check current state
- [ ] Run `task dotfiles` on a test machine to verify symlinks
- [ ] Run `task brew:bundle` to install new packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)